### PR TITLE
Several event page updates, copyright year changes.

### DIFF
--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -149,7 +149,7 @@
 				<!--End mc_embed_signup-->
 					
 					<ul class="copyright">
-						<li>GenghisCon &copy; 2020</li>
+						<li>GenghisCon &copy; 2021</li>
 						<li>Design: <a href="http://templated.co">TEMPLATED</a></li>
 					</ul>
 				</div>

--- a/contactus.html
+++ b/contactus.html
@@ -108,7 +108,7 @@
 				<!--End mc_embed_signup-->
 					
 					<ul class="copyright">
-						<li>GenghisCon &copy; 2020</li>
+						<li>GenghisCon &copy; 2021</li>
 						<li>Design: <a href="http://templated.co">TEMPLATED</a></li>
 					</ul>
 				</div>

--- a/eventinformation.html
+++ b/eventinformation.html
@@ -77,7 +77,7 @@
 							  <header class="major"> 
 									<h2>The Maze at <a href="https://outbacksplash.com.au/">Perth's Outback Splash</a></h2>
 								</header>
-							  <p>GhenghisCon will be at The Maze - 19<sup>th</sup> September 2021, 11:00AM to 4:00PM</p>
+							  <p>GenghisCon will be at The Maze - 19<sup>th</sup> September 2021, 11:00AM to 4:00PM</p>
                           </div>
 						</div>
 					</div>

--- a/eventinformation.html
+++ b/eventinformation.html
@@ -31,27 +31,32 @@
 
 		<!-- Banner -->
 			<section id="banner">
-				<h2 class="dropshadow">Event Information</h2>
+				<h2 class="dropshadow">Event Information</h2
 				<ul class="actions">
 				</ul>
 			</section>
-							
 							
 			<!-- One -->
 				<section id="one" class="wrapper style1">
 					<div class="container 75%">
 						<div class="row 200%">
 							<div class="contact 6u 12u$(medium)">
-							  <header class="major"> 
-									<h2>The Maze at <a href="https://outbacksplash.com.au/">Perth's Outback Splash</a></h2>
-								</header>
-							  <p>GhenghisCon will be at The Maze - 19<sup>th</sup> September 2021, 11:00AM to 4:00PM</p>
+						<header class="major">
+							<h2>2022 tickets now available!</h2>
+							<p>Weekend tickets from $25</p>
+						</header>
+						<ul class="actions">
+						  <li><a href="https://sites.grenadine.co/sites/genghiscon/en/genghiscon2022/register" class="button special big">Register Now!</a></li>
+						</ul>
                           </div>
 						</div>
 					</div>
 				</section>
 
-				<section id="one" class="wrapper style1">
+							<div style="text-align:center">
+							<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&bgcolor=%23ffffff&ctz=Australia%2FPerth&src=Z2VuZ2hpc2NvbnBlcnRoQGdtYWlsLmNvbQ&src=YWRkcmVzc2Jvb2sjY29udGFjdHNAZ3JvdXAudi5jYWxlbmRhci5nb29nbGUuY29t&src=aDNpcThpZ2RwOGs2NWlkNzIzdjZhdXYxMDhAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ&color=%23039BE5&color=%2333B679&color=%23C0CA33" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe></div>
+
+				<section id="two" class="wrapper style1">
 					<div class="container 75%">
 						<div class="row 200%">
 							<div class="contact 6u 12u$(medium)">
@@ -64,7 +69,22 @@
 					</div>
 				</section>
 
-				<section id="one" class="wrapper style1">
+
+				<section id="three" class="wrapper style1">
+					<div class="container 75%">
+						<div class="row 200%">
+							<div class="contact 6u 12u$(medium)">
+							  <header class="major"> 
+									<h2>The Maze at <a href="https://outbacksplash.com.au/">Perth's Outback Splash</a></h2>
+								</header>
+							  <p>GhenghisCon will be at The Maze - 19<sup>th</sup> September 2021, 11:00AM to 4:00PM</p>
+                          </div>
+						</div>
+					</div>
+				</section>
+
+
+				<section id="four" class="wrapper style1">
 					<div class="container 75%">
 						<div class="row 200%">
 							<div class="contact 6u 12u$(medium)">
@@ -114,12 +134,12 @@
 				</section>
 
 			<!-- Three -->
-				<section id="one" class="wrapper style1">
+				<section id="five" class="wrapper style1">
 					<div class="container 75%">
 						<div class="row 200%">
 						  <div class="contact 6u 12u$(medium)">
 						    <header class="major"> 
-									<h2> Covid-19</h2>
+									<h2>Covid-19</h2>
 										<p>What happens if the con doesn't run in 2022?</p>
 							  </header>
 						    <p> If GenghisCon needs to be cancelled because of government or health recommendations, all tickets brought through grenadine will be <a href="mailto:genghisconperth@gmail.com?subject=Refund%20-%20YOUR%20NAME">refunded on request via email to genghisconperth@gmail.com</a> (provide your name), or honoured as 2022 tickets. Unfortunately, we cannot guarantee a refund for accommodation or meal tickets. These refunds are at the discretion of St Georges College. </p>
@@ -130,17 +150,6 @@
 				</section>
 
 			<!-- Four -->
-				<section id="four" class="wrapper style3 special">
-					<div class="container">
-						<header class="major">
-							<h2>2022 tickets coming soon!</h2>
-							<p>Weekend tickets from $25</p>
-						</header>
-						<ul class="actions">
-						  <li><a href="https://sites.grenadine.co/sites/genghiscon/en/genghiscon2021/register" class="button special big">Register Now!</a></li>
-						</ul>
-					</div>
-				</section>
 
 		<!-- Footer -->
 			<footer id="footer">
@@ -180,7 +189,7 @@
 				<!--End mc_embed_signup-->
 							
 					<ul class="copyright">
-						<li>GenghisCon &copy; 2020</li>
+						<li>GenghisCon &copy; 2021</li>
 						<li>Design: <a href="http://templated.co">TEMPLATED</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
Add 2022 convention registration to events page.
Fix Copyright year on each page.
Reorder events, most recent first.
Add GenghisCon Events (Google Calendar) embed to events page.
Signed-off-by: awjob@internode.on.net <Adam Ward>