### PR TITLE
Change contact email address to use committee@genghiscon.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@ Please contact <a href="mailto:xiyanala@gmail.com?subject=GenghisCon%202022%20Tr
 							        </div>
 							</div>
 						</div>
-						<p style="text-align:center">Get in contact via the <a href="mailto:genghisconperth@gmail.com">Genghiscon Perth email genghisconperth@gmail.com</a></p>
+						<p style="text-align:center">Get in contact via the <a href="mailto:committee@genghiscon.org">Genghiscon Perth email committee@genghiscon.org</a></p>
 					</div>
 				<div class="container">
 				<header class="major special">


### PR DESCRIPTION
We have a configuration at forwardemail.net to point any name @ our domain to the gmail account.

Signed-off-by: adam-ward-git@mrasw.id.au <Adam Ward>